### PR TITLE
Add support for recent Institute of Physics (IOP) journals articles

### DIFF
--- a/app/scripts/extractor.js
+++ b/app/scripts/extractor.js
@@ -58,6 +58,16 @@ var rules = {
         fulltext: '$("article main").html() + $("footer .ref-list").html()',
         year: '$(".article-dates dd time").get()[0].innerHTML.split("-")[0]',
         doi: '$(".self-citation a:first").text().replace("http://dx.doi.org/", "")'
+    },
+    'IOPScience': {
+        url: /iopscience.iop.org\/.*?\/article/,
+        journal: '$("ul.breadcrumbs li:nth-child(1) a").text()',
+        title: '$("div.publishingInfo h2").text().trim()',
+        authors: '$("p.authors").clone().children().remove().end().text().replace(" and ", ", ")',
+        abstract: '$("div.abst div div").text().trim()',
+        fulltext: '$("div.section:nth(1)").html() + $("dl.citationlist").html()',
+        year: '$("div.publishingInfo p:contains(\'©\')").html().split("<br>")[0].trim().split(" ")[1]',
+        doi: '$("div.publishingInfo p a:contains(\'doi\')").text().split(":")[1]'
     }
 };
 


### PR DESCRIPTION
Multiple journals are supported like this, as IOP hosts all of them on the same website. I Have some examples of working articles [1](http://iopscience.iop.org/1367-2630/16/6/063043/article), [2](http://iopscience.iop.org/0029-5515/54/6/064001/article). The scraping matches current formatting. Unfortunately the formatting
was different a few years back, for example [3](http://iopscience.iop.org/1367-2630/8/9/188/fulltext/). Those are not handled by these rules, and would need to implement separately.

I added these changes to the extractor.js only (because of what I've seen in your blogpost), looks like that there are other areas in the code that replicate the same section of code. I couldn't totally test this code, would appreciate feedback!
